### PR TITLE
Removed `enable_containers` setting

### DIFF
--- a/TSKubernetesDaemonSet.yaml
+++ b/TSKubernetesDaemonSet.yaml
@@ -71,7 +71,7 @@ spec:
           - name: THREATSTACK_SETUP_ARGS
             value: "--deploy-key <REPLACE_WITH_VALID_DEPLOY_KEY> --ruleset 'Base Rule Set, Docker Rule Set, Kubernetes Rule Set'"
           - name: THREATSTACK_CONFIG_ARGS
-            value: "enable_kubes 1 enable_containers 1 enable_kubes_master 1 log.level info"
+            value: "enable_kubes 1 enable_kubes_master 1 log.level info"
         securityContext:
           privileged: false
           capabilities:


### PR DESCRIPTION
I don't think we want `enable_containers` set on the API monitoring pod.